### PR TITLE
RE Rename README.md to README

### DIFF
--- a/README
+++ b/README
@@ -7,12 +7,8 @@ For all those things you.... probably shouldn't have been doing anyway....
 Ubuntu Installation
 ===================
 ```
-git clone https://github.com/padraic/runkit.git
-cd runkit
-phpize
-./configure
-make
-sudo make install
+git clone https://github.com/padraic/runkit.git /tmp/runkit
+pecl install /tmp/runkit/package.xml
 sudo bash -c "echo 'extension=runkit.so' > /etc/php5/mods-available/runkit.ini"
 sudo php5enmod runkit
 ```


### PR DESCRIPTION
PHP5.6 on Ubuntu 14.04 LTS

$ git clone https://github.com/padraic/runkit /tmp/runkit
$ sudo pecl install /tmp/runkit/package.xml
ERROR: file /tmp/runkit/README does not exist

Build process completed successfully after rename README.

$ pecl list -a
# Installed packages, channel __uri:

Package Version State
# runkit  1.0.4   stable

.
.
.
